### PR TITLE
feat: add useSignInWithEmailAndPasswordMutation hook

### DIFF
--- a/packages/react/src/auth/index.ts
+++ b/packages/react/src/auth/index.ts
@@ -21,7 +21,7 @@ export { useSendSignInLinkToEmailMutation } from "./useSendSignInLinkToEmailMuta
 export { useSignInAnonymouslyMutation } from "./useSignInAnonymouslyMutation";
 // useSignInWithCredentialMutation
 // useSignInWithCustomTokenMutation
-// useSignInWithEmailAndPasswordMutation
+export { useSignInWithEmailAndPasswordMutation } from "./useSignInWithEmailAndPasswordMutation";
 // useSignInWithEmailLinkMutation
 // useSignInWithPhoneNumberMutation
 // useSignInWithPopupMutation

--- a/packages/react/src/auth/useSignInWithEmailAndPasswordMutation.test.tsx
+++ b/packages/react/src/auth/useSignInWithEmailAndPasswordMutation.test.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import {
+  describe,
+  expect,
+  test,
+  beforeEach,
+  afterEach,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useSignInWithEmailAndPasswordMutation } from "./useSignInWithEmailAndPasswordMutation";
+import { auth, wipeAuth } from "~/testing-utils";
+import { createUserWithEmailAndPassword } from "firebase/auth";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+    mutations: { retry: false },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe("useSignInWithEmailAndPasswordMutation", () => {
+  beforeEach(async () => {
+    queryClient.clear();
+    await wipeAuth();
+  });
+
+  afterEach(async () => {
+    await auth.signOut();
+  });
+
+  test("successfully signs in with email and password", async () => {
+    const email = "tqf@invertase.io";
+    const password = "tanstackQueryFirebase#123";
+    await createUserWithEmailAndPassword(auth, email, password);
+
+    const { result } = renderHook(
+      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      { wrapper }
+    );
+
+    await act(async () => result.current.mutate());
+
+    await waitFor(async () => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.user.email).toBe(email);
+  });
+
+  test("fails to sign in with incorrect password", async () => {
+    const email = "tqf@invertase.io";
+    const password = "tanstackQueryFirebase#123";
+    const wrongPassword = "wrongpassword";
+
+    await createUserWithEmailAndPassword(auth, email, password);
+
+    const { result } = renderHook(
+      () => useSignInWithEmailAndPasswordMutation(auth, email, wrongPassword),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.isSuccess).toBe(false);
+    // TODO: Assert Firebase error for auth/wrong-password
+  });
+
+  test("fails to sign in with non-existent email", async () => {
+    const email = "tqf@invertase.io";
+    const password = "tanstackQueryFirebase#123";
+
+    const { result } = renderHook(
+      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.isSuccess).toBe(false);
+    // TODO: Assert Firebase error for auth/user-not-found
+  });
+
+  test("handles empty email input", async () => {
+    const email = "";
+    const password = "validPassword123";
+
+    const { result } = renderHook(
+      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.isSuccess).toBe(false);
+    // TODO: Assert Firebase error for auth/invalid-email
+  });
+
+  test("handles empty password input", async () => {
+    const email = "tqf@invertase.io";
+    const password = "";
+
+    const { result } = renderHook(
+      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.isSuccess).toBe(false);
+    // TODO: Assert Firebase error for auth/missing-password
+  });
+
+  test("handles concurrent sign in attempts", async () => {
+    const email = "tqf@invertase.io";
+    const password = "tanstackQueryFirebase#123";
+
+    await createUserWithEmailAndPassword(auth, email, password);
+
+    const { result } = renderHook(
+      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      { wrapper }
+    );
+
+    // Attempt multiple concurrent sign-ins
+    await act(async () => {
+      result.current.mutate();
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.user.email).toBe(email);
+  });
+
+  test("handles sign in with custom mutation options", async () => {
+    const email = "tqf@invertase.io";
+    const password = "tanstackQueryFirebase#123";
+
+    const onSuccessMock = vi.fn();
+
+    await createUserWithEmailAndPassword(auth, email, password);
+
+    const { result } = renderHook(
+      () =>
+        useSignInWithEmailAndPasswordMutation(auth, email, password, {
+          onSuccess: onSuccessMock,
+        }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(onSuccessMock).toHaveBeenCalled();
+    expect(result.current.data?.user.email).toBe(email);
+  });
+});

--- a/packages/react/src/auth/useSignInWithEmailAndPasswordMutation.test.tsx
+++ b/packages/react/src/auth/useSignInWithEmailAndPasswordMutation.test.tsx
@@ -1,13 +1,5 @@
 import React from "react";
-import {
-  describe,
-  expect,
-  test,
-  beforeEach,
-  afterEach,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useSignInWithEmailAndPasswordMutation } from "./useSignInWithEmailAndPasswordMutation";
@@ -41,11 +33,11 @@ describe("useSignInWithEmailAndPasswordMutation", () => {
     await createUserWithEmailAndPassword(auth, email, password);
 
     const { result } = renderHook(
-      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      () => useSignInWithEmailAndPasswordMutation(auth),
       { wrapper }
     );
 
-    await act(async () => result.current.mutate());
+    await act(async () => result.current.mutate({ email, password }));
 
     await waitFor(async () => expect(result.current.isSuccess).toBe(true));
 
@@ -60,12 +52,12 @@ describe("useSignInWithEmailAndPasswordMutation", () => {
     await createUserWithEmailAndPassword(auth, email, password);
 
     const { result } = renderHook(
-      () => useSignInWithEmailAndPasswordMutation(auth, email, wrongPassword),
+      () => useSignInWithEmailAndPasswordMutation(auth),
       { wrapper }
     );
 
     await act(async () => {
-      result.current.mutate();
+      result.current.mutate({ email, password: wrongPassword });
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
@@ -80,12 +72,12 @@ describe("useSignInWithEmailAndPasswordMutation", () => {
     const password = "tanstackQueryFirebase#123";
 
     const { result } = renderHook(
-      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      () => useSignInWithEmailAndPasswordMutation(auth),
       { wrapper }
     );
 
     await act(async () => {
-      result.current.mutate();
+      result.current.mutate({ email, password });
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
@@ -100,12 +92,12 @@ describe("useSignInWithEmailAndPasswordMutation", () => {
     const password = "validPassword123";
 
     const { result } = renderHook(
-      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      () => useSignInWithEmailAndPasswordMutation(auth),
       { wrapper }
     );
 
     await act(async () => {
-      result.current.mutate();
+      result.current.mutate({ email, password });
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
@@ -120,12 +112,12 @@ describe("useSignInWithEmailAndPasswordMutation", () => {
     const password = "";
 
     const { result } = renderHook(
-      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      () => useSignInWithEmailAndPasswordMutation(auth),
       { wrapper }
     );
 
     await act(async () => {
-      result.current.mutate();
+      result.current.mutate({ email, password });
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
@@ -142,14 +134,14 @@ describe("useSignInWithEmailAndPasswordMutation", () => {
     await createUserWithEmailAndPassword(auth, email, password);
 
     const { result } = renderHook(
-      () => useSignInWithEmailAndPasswordMutation(auth, email, password),
+      () => useSignInWithEmailAndPasswordMutation(auth),
       { wrapper }
     );
 
     // Attempt multiple concurrent sign-ins
     await act(async () => {
-      result.current.mutate();
-      result.current.mutate();
+      result.current.mutate({ email, password });
+      result.current.mutate({ email, password });
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -167,14 +159,14 @@ describe("useSignInWithEmailAndPasswordMutation", () => {
 
     const { result } = renderHook(
       () =>
-        useSignInWithEmailAndPasswordMutation(auth, email, password, {
+        useSignInWithEmailAndPasswordMutation(auth, {
           onSuccess: onSuccessMock,
         }),
       { wrapper }
     );
 
     await act(async () => {
-      result.current.mutate();
+      result.current.mutate({ email, password });
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/packages/react/src/auth/useSignInWithEmailAndPasswordMutation.ts
+++ b/packages/react/src/auth/useSignInWithEmailAndPasswordMutation.ts
@@ -6,19 +6,27 @@ import {
   type UserCredential,
 } from "firebase/auth";
 
-type SignInWithEmailAndPassword = Omit<
-  UseMutationOptions<UserCredential, AuthError, void>,
-  "mutationFn"
->;
+type AuthUseMutationOptions<
+  TData = unknown,
+  TError = Error,
+  TVariables = void
+> = Omit<UseMutationOptions<TData, TError, TVariables>, "mutationFn">;
 
 export function useSignInWithEmailAndPasswordMutation(
   auth: Auth,
-  email: string,
-  password: string,
-  options?: SignInWithEmailAndPassword
+  options?: AuthUseMutationOptions<
+    UserCredential,
+    AuthError,
+    { email: string; password: string }
+  >
 ) {
-  return useMutation<UserCredential, AuthError>({
+  return useMutation<
+    UserCredential,
+    AuthError,
+    { email: string; password: string }
+  >({
     ...options,
-    mutationFn: () => signInWithEmailAndPassword(auth, email, password),
+    mutationFn: ({ email, password }) =>
+      signInWithEmailAndPassword(auth, email, password),
   });
 }

--- a/packages/react/src/auth/useSignInWithEmailAndPasswordMutation.ts
+++ b/packages/react/src/auth/useSignInWithEmailAndPasswordMutation.ts
@@ -1,0 +1,24 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+import {
+  type Auth,
+  type AuthError,
+  signInWithEmailAndPassword,
+  type UserCredential,
+} from "firebase/auth";
+
+type SignInWithEmailAndPassword = Omit<
+  UseMutationOptions<UserCredential, AuthError, void>,
+  "mutationFn"
+>;
+
+export function useSignInWithEmailAndPasswordMutation(
+  auth: Auth,
+  email: string,
+  password: string,
+  options?: SignInWithEmailAndPassword
+) {
+  return useMutation<UserCredential, AuthError>({
+    ...options,
+    mutationFn: () => signInWithEmailAndPassword(auth, email, password),
+  });
+}


### PR DESCRIPTION
This PR adds `useSignInWithEmailAndPasswordMutation` hook.
<img width="477" alt="image" src="https://github.com/user-attachments/assets/e9b64e85-448e-432d-833c-de13d8e1c296">
