### PR TITLE
chore(react/firestore): remove obsolete useEnableIndexedDbPersistenceMutation

### DIFF
--- a/packages/react/src/firestore/index.ts
+++ b/packages/react/src/firestore/index.ts
@@ -1,5 +1,4 @@
 export { useClearIndexedDbPersistenceMutation } from "./useClearIndexedDbPersistenceMutation";
-// useEnableIndexedDbPersistenceMutation
 export { useDisableNetworkMutation } from "./useDisableNetworkMutation";
 // useEnableNetworkMutation
 export { useWaitForPendingWritesQuery } from "./useWaitForPendingWritesQuery";


### PR DESCRIPTION
This PR removes `useEnableIndexedDbPersistenceMutation` as the API is now obsolete.