### PR TITLE
chore(react/auth): remove useFetchSignInMethodsForEmailQuery

### DIFF
--- a/packages/react/src/auth/index.ts
+++ b/packages/react/src/auth/index.ts
@@ -13,7 +13,6 @@
 // useCheckActionCodeMutation
 // useConfirmPasswordResetMutation
 // useCreateUserWithEmailAndPasswordMutation
-// useFetchSignInMethodsForEmailQuery
 // useGetRedirectResultQuery
 // useRevokeAccessTokenMutation
 // useSendPasswordResetEmailMutation


### PR DESCRIPTION
This pr removes `useFetchSignInMethodsForEmailQuery` as `fetchSignInMethodsForEmail` has got some deprecated parts.