### PR TITLE
Fixed issue where node module resolution wasn't being respected

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,24 +10,25 @@
 		"serve:coverage": "npx serve coverage",
 		"emulator": "firebase emulators:start --project test-project",
 		"emulator:kill": "lsof -t -i:4001 -i:8080 -i:9000 -i:9099 -i:9199 -i:8085 | xargs kill -9",
-		"check": "pnpm biome check --write ./packages/react/src"
+		"check": "pnpm biome check --write ./packages/react/src",
+		"publish-package": "pnpm run build && cd dist && npm publish"
 	},
 	"exports": {
 		".": {
-			"import": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"import": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./auth": {
-			"import": "./dist/auth/index.js",
-			"types": "./dist/auth/index.d.ts"
+			"import": "./auth/index.js",
+			"types": "./auth/index.d.ts"
 		},
 		"./firestore": {
-			"import": "./dist/firestore/index.js",
-			"types": "./dist/firestore/index.d.ts"
+			"import": "./firestore/index.js",
+			"types": "./firestore/index.d.ts"
 		},
 		"./data-connect": {
-			"import": "./dist/data-connect/index.js",
-			"types": "./dist/data-connect/index.d.ts"
+			"import": "./data-connect/index.js",
+			"types": "./data-connect/index.d.ts"
 		}
 	},
 	"author": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,10 +36,6 @@
 		"email": "oss@invertase.io",
 		"url": "https://github.com/invertase/tanstack-query-firebase"
 	},
-	"files": [
-		"dist",
-		"README.md"
-	],
 	"license": "Apache-2.0",
 	"devDependencies": {
 		"@dataconnect/default-connector": "workspace:*",

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "tsup";
-
+import * as fs from 'node:fs/promises';
 const supportedPackages = ['data-connect', 'firestore', 'auth'];
 export default defineConfig({
 	entry: [`src/(${supportedPackages.join('|')})/index.ts`, 'src/index.ts'],
@@ -11,4 +11,13 @@ export default defineConfig({
 	},
 	// splitting: false, // Disable code splitting to generate distinct files
 	clean: true,
+	async onSuccess() {
+		try {
+			await fs.copyFile('./package.json', './dist/package.json');
+			await fs.copyFile('./README.md', './dist/README.md');
+			await fs.copyFile('./LICENSE', './dist/LICENSE');
+		} catch (e) {
+			console.error(`Error copying files: ${e}`);
+		}
+	}
 });


### PR DESCRIPTION
In `tsconfig.json`, when `moduleResolution` is set to `node`, then the `exports` field is ignored, and instead resolution happens based on paths relative to the root `package.json`. For example, if `@tanstack-query-firebase/react` is imported from, then like normal, the package.json in the root of the package is referenced. Then, if the user has a subpath import, such as `@tanstack-query-firebase/react/data-connect`, then, as the node module resolution doesn't understand the exports field, looks for types at the `data-connect` folder, relative to the root package.json. This PR allows users to use the `node` module resolution and any future ones that respect the `exports` field as well.

**Note: This requires publishing from the `dist` folder, so the `publish-package` script was copied over from the angular package.**