### PR TITLE
chore(docs): add missing import to react index.mdx

### DIFF
--- a/docs/react/index.mdx
+++ b/docs/react/index.mdx
@@ -21,7 +21,7 @@ and [configure TanStack Query](https://tanstack.com/query/latest/docs/framework/
 
 ```jsx
 import { initializeApp } from 'firebase/app';
-import { QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // TODO: Replace the following with your app's Firebase project configuration
 const firebaseConfig = {


### PR DESCRIPTION
Added "QueryClient" to the React imports to improve copy-paste usability when trying the demo from the documentation."